### PR TITLE
Align repo with README skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 ui/node_modules/
 node_modules/
 data/**/*.parquet
+__pycache__/

--- a/api/Models/Flight.cs
+++ b/api/Models/Flight.cs
@@ -1,0 +1,3 @@
+namespace FlightFareApi.Models;
+
+public record Flight(string Airline, string Flight, string Source, string Destination, decimal Price, int DaysLeft);

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -6,6 +6,7 @@ using Dapper;
 using DuckDB.NET.Data;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.OpenApi.Models;
+using FlightFareApi.Repositories;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -30,6 +31,7 @@ builder.Services.AddSingleton<IDbConnection>(sp =>
     conn.Open();
     return conn;
 });
+builder.Services.AddSingleton<FlightRepository>();
 
 builder.Services.AddSignalR();
 builder.Services.AddEndpointsApiExplorer();
@@ -97,6 +99,15 @@ app.MapGet("/prices/history", async (IDbConnection conn) =>
 })
 .WithName("PriceHistory")
 .WithTags("Prices");
+
+// Latest flights using repository
+app.MapGet("/flights/latest", async (FlightRepository repo) =>
+{
+    var rows = await repo.GetLatestFlightsAsync();
+    return Results.Ok(rows);
+})
+.WithName("LatestFlights")
+.WithTags("Flights");
 
 // Endpoint to broadcast a manual message (demo only)
 app.MapPost("/broadcast", async (BroadcastRequest req, IHubContext<LiveFeedHub> hub) =>

--- a/api/Repositories/FlightRepository.cs
+++ b/api/Repositories/FlightRepository.cs
@@ -1,0 +1,19 @@
+using System.Data;
+using Dapper;
+
+namespace FlightFareApi.Repositories;
+
+public class FlightRepository
+{
+    private readonly IDbConnection _db;
+    public FlightRepository(IDbConnection db)
+    {
+        _db = db;
+    }
+
+    public async Task<IEnumerable<dynamic>> GetLatestFlightsAsync()
+    {
+        const string sql = "SELECT * FROM flights_gold ORDER BY load_ts DESC LIMIT 100";
+        return await _db.QueryAsync(sql);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+services:
+  api:
+    image: mcr.microsoft.com/dotnet/sdk:8.0
+    working_dir: /src/api
+    volumes:
+      - ./api:/src/api
+      - ./data:/src/data
+    command: ["dotnet", "run", "--urls", "http://0.0.0.0:8080"]
+    ports:
+      - "8000:8080"
+
+  etl:
+    image: python:3.12-slim
+    working_dir: /src/etl
+    volumes:
+      - ./etl:/src/etl
+      - ./data:/src/data
+    command: ["sleep", "infinity"]
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "8080:80"
+    volumes:
+      - ./ui:/usr/share/nginx/html:ro

--- a/etl/tests/test_transform.py
+++ b/etl/tests/test_transform.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from transform import normalise
+
+def test_normalise_basic():
+    df = pd.DataFrame({
+        'stops': ['non-stop', '1 stop'],
+        'departure_time': ['Morning', 'Evening'],
+        'duration': ['2.0', '3.5'],
+        'price': [100, 200],
+        'days_left': [30, 40],
+        'airline': ['A', 'B'],
+        'class': ['Economy', 'Business'],
+    })
+    out = normalise(df)
+    # Verify new columns exist
+    expected_cols = {
+        'stops_n', 'dep_bucket', 'duration_mins', 'price_z',
+        'days_left_scaled', 'airline_freq', 'cls_Economy', 'cls_Business', 'log_price'
+    }
+    assert expected_cols.issubset(out.columns)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pandas
+polars
+duckdb
+pyarrow
+great_expectations


### PR DESCRIPTION
## Summary
- set up docker-compose for API, ETL, and Nginx static UI
- add FlightRepository and Flight model for Dapper queries
- extend Program.cs with repository and new endpoint
- provide minimal pytest for transform step
- track Python requirements and ignore `__pycache__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688be06db4048333b450c16107f19113