### PR TITLE
Improve README with quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,107 +1,46 @@
-### **Re-scoped Blueprint — “Flight-Fare Intelligence Dashboard 2.0”**
+# Flight-Fare Intelligence Dashboard
 
-*Keep the original “messy-to-insight” storyline, swap the relational DB for **columnar Parquet storage**, and layer in richer data-science touches (eight flavours of normalisation + eight distinct visualisations).*
+This demo project turns a raw airline fare CSV into a set of interactive charts. Python scripts clean and normalise the data into Parquet, a .NET Minimal API exposes queries over DuckDB, and a small HTMX/Tailwind front-end renders the dashboard.
 
----
+## Quick start
 
-## 1 | Architecture (Zero DB Server)
+Run the following commands from the repo root to generate data and launch the dashboard.
 
-| Layer                      | Technology                                                                                      | Rationale                                                                              |
-| -------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| **Extraction / Cleansing** | Python 3.12 · Pandas + Polars + Great Expectations                                              | Fast, memory-efficient wrangling; automated data-quality gates                         |
-| **Storage**                | **Partitioned Parquet files** (Arrow format)                                                    | Column-ar, compressed, analytics-friendly; lives in Git repo / S3 without a running DB |
-| **Query Engine**           | **DuckDB embedded** (single `.duckdb` file) exposed via ODBC → accessed from C# with **Dapper** | Gives us SQL + Dapper mapping **without** a server; DuckDB reads Parquet natively      |
-| **API**                    | .NET 8 Minimal API + Dapper • SignalR for live stream                                           | Thin, strongly-typed endpoints; WebSocket push for “live” feed                         |
-| **Front-End**              | Vanilla HTML • Tailwind CSS • HTMX + Chart.js                                                   | Instant responsive UI, no heavy SPA framework                                          |
+```bash
+# 1. Python dependencies
+pip install -r requirements.txt
 
-> **Why this still counts as “no DB”?** DuckDB is an embedded analytics engine that simply maps SQL onto the Parquet files on disk—there’s no server to install or manage.
+# 2. Extract & transform the sample data
+python etl/extract_excel.py --source data/raw/airlines_flights_data.csv
+python etl/transform.py
 
----
+# 3. Build Tailwind CSS for the UI
+cd ui
+npm install
+npx tailwindcss -o public/tailwind.css --minify
+cd ..
 
-## 2 | Eight Normalisation/Transformation Techniques
+# 4. Start API and dashboard
+docker compose up --build
 
-| #     | Category                      | Flight-column Example                                      | Purpose                                            |
-| ----- | ----------------------------- | ---------------------------------------------------------- | -------------------------------------------------- |
-| **1** | **Categorical harmonisation** | `stops → {0,1,2}`                                          | Removes free-text drift (“zero”, “non-stop”, etc.) |
-| **2** | **Time-bucket encoding**      | `departure_time → {Early Morning, Morning…}` ⟶ ordinal 0-5 | Feeds ML models numeric chrono order               |
-| **3** | **Duration unwrap**           | `"2.17"` h ⟶ `130` minutes                                 | Consistent numeric metric                          |
-| **4** | **Z-score scaling**           | `price_z = (price – µ) / σ`                                | Detect over/under-priced outliers                  |
-| **5** | **Min-max scaling**           | `days_left` 0-365 ⟶ 0-1                                    | Feature range for UI sliders                       |
-| **6** | **Frequency encoding**        | `airline_freq` = share of flights                          | Captures carrier popularity                        |
-| **7** | **One-hot vectors**           | `class ∈ {Economy, Business}`                              | Keeps class bias explicit                          |
-| **8** | **Log-transform**             | `log_price = ln(price)`                                    | Normalises right-skewed fare tail                  |
-
-Each transformation lives in `etl/transform.py` with unit‐tests (`pytest`) and Great Expectations checks.
-
----
-
-## 3 | Eight Visual Styles Showcased in the Dashboard
-
-| #     | Component                                                                   | Insight Conveyed                 |
-| ----- | --------------------------------------------------------------------------- | -------------------------------- |
-| **1** | **Line chart** (Chart.js) – Median price vs. `days_left`                    | Price-decay curve                |
-| **2** | **Box-and-whisker** – Fare distribution per airline                         | Detect carrier outliers          |
-| **3** | **Heat-map calendar** – Avg. price by departure weekday & month             | Seasonality hotspots             |
-| **4** | **Stacked area** – Class mix share over time                                | Economy vs. Business trends      |
-| **5** | **Violin plot** – Flight **duration** by `stops` count                      | Time cost of layovers            |
-| **6** | **Bullet KPI cards** – Data-quality score, null-rate, row latency           | Health at a glance               |
-| **7** | **Radar chart** – Z-scored metrics (price, duration, days\_left) by airline | Multi-metric carrier ranking     |
-| **8** | **Live ticker table** (HTMX stream) – Last 20 price updates                 | “Bloomberg”-style real-time feed |
-
-All charts share the Tailwind theme but differ in form, emphasising your versatility with data storytelling.
-
----
-
-## 4 | 7-Day Sprint Plan (updated)
-
-| Day   | Deliverables                                                                                | Key Analyst/Engineer Focus |
-| ----- | ------------------------------------------------------------------------------------------- | -------------------------- |
-| **1** | Jupyter EDA of raw Excel → identify anomalies                                               | Problem framing            |
-| **2** | Build **`extract_excel.py`** → convert to partitioned Parquet (`/data/YYYY-MM/…`)           | Efficient columnar storage |
-| **3** | Implement **8 transformations** + tests; generate Great Expectations docs                   | Reproducible cleansing     |
-| **4** | Spin up DuckDB; wire Dapper queries (`flights_latest`, `price_hist`)                        | Embedded SQL access        |
-| **5** | Create Minimal API endpoints + SignalR hub; fake live feed via `python stream_simulator.py` | Real-time backend          |
-| **6** | Tailwind dashboard with **8 visual widgets**; HTMX filters                                  | Interactive UX             |
-| **7** | Docker Compose (Python + API + Nginx); GitHub CI; 90-sec demo video                         | Dev-ops polish             |
-
----
-
-## 5 | Repository Skeleton
-
-```
-flight-fare-dashboard/
-├─ data/
-│  └─ (Parquet partitions)
-├─ etl/
-│  ├─ extract_excel.py
-│  ├─ transform.py
-│  ├─ stream_simulator.py
-│  └─ tests/
-├─ api/
-│  ├─ Program.cs          # .NET 8 + SignalR
-│  ├─ Repositories/       # Dapper <-> DuckDB ODBC
-│  └─ Models/
-├─ ui/
-│  ├─ index.html
-│  ├─ tailwind.css
-│  └─ js/
-├─ docker-compose.yml
-└─ README.md
+# (Optional) emit a live JSON feed
+python etl/stream_simulator.py --gold data/gold/flights_gold_*.parquet
 ```
 
+The API listens on `http://localhost:8000` and the dashboard is served at `http://localhost:8080`.
+
+## Architecture overview
+
+| Layer            | Technology                              | Purpose                                      |
+| ---------------- | --------------------------------------- | -------------------------------------------- |
+| Extraction       | Python · Pandas/Polars                  | Load and validate the raw CSV/Excel          |
+| Storage          | Parquet partitions                      | Compressed, analytics-friendly files         |
+| Query engine     | DuckDB embedded + Dapper                | SQL access without a running database server |
+| API              | .NET 8 Minimal API + SignalR            | REST endpoints and optional live feed        |
+| Front-end        | Tailwind CSS · HTMX · Chart.js          | Lightweight interactive dashboard            |
+
+The transformation step applies eight normalisation techniques (bucketed times, z-scores, one-hot encoding, etc.). The dashboard showcases various chart types including line, box/whisker and heat maps.
+
 ---
 
-## 6 | Interview Sound-Bites
-
-* **“No server, still SQL.”** - DuckDB queries Parquet in-process; Dapper maps straight into C# DTOs—easy to demo locally or in CI.
-* **“Eight-layer normalisation.”** - I showcase categorical, numerical, and statistical techniques, each backed by tests and Great Expectations validation.
-* **“Visual buffet.”** - From box-plots to live tickers, the UI proves I can pick the right chart for the story—not just default line graphs.
-* **“One-command spin-up.”** - `docker compose up` builds ETL, API, and Tailwind-served UI in \~90 s.
-
----
-
-### **Elevator Pitch (final form)**
-
-> “I take a messy Excel flight-fare dump, enforce eight rigorous normalisation steps, store it as efficient Parquet, query it with embedded DuckDB + Dapper (no external DB), and present eight distinct visual perspectives—all containerised, tested, and ready for a hiring manager to explore in one click.”
-
-Use this plan as your project README outline, then iterate feature-by-feature; the result is a **compact yet sophisticated** showcase of both analysis depth and engineering practicality.
+Original blueprint details can be found in [`README.md.bak`](README.md.bak).

--- a/README.md.bak
+++ b/README.md.bak
@@ -1,0 +1,107 @@
+### **Re-scoped Blueprint — “Flight-Fare Intelligence Dashboard 2.0”**
+
+*Keep the original “messy-to-insight” storyline, swap the relational DB for **columnar Parquet storage**, and layer in richer data-science touches (eight flavours of normalisation + eight distinct visualisations).*
+
+---
+
+## 1 | Architecture (Zero DB Server)
+
+| Layer                      | Technology                                                                                      | Rationale                                                                              |
+| -------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| **Extraction / Cleansing** | Python 3.12 · Pandas + Polars + Great Expectations                                              | Fast, memory-efficient wrangling; automated data-quality gates                         |
+| **Storage**                | **Partitioned Parquet files** (Arrow format)                                                    | Column-ar, compressed, analytics-friendly; lives in Git repo / S3 without a running DB |
+| **Query Engine**           | **DuckDB embedded** (single `.duckdb` file) exposed via ODBC → accessed from C# with **Dapper** | Gives us SQL + Dapper mapping **without** a server; DuckDB reads Parquet natively      |
+| **API**                    | .NET 8 Minimal API + Dapper • SignalR for live stream                                           | Thin, strongly-typed endpoints; WebSocket push for “live” feed                         |
+| **Front-End**              | Vanilla HTML • Tailwind CSS • HTMX + Chart.js                                                   | Instant responsive UI, no heavy SPA framework                                          |
+
+> **Why this still counts as “no DB”?** DuckDB is an embedded analytics engine that simply maps SQL onto the Parquet files on disk—there’s no server to install or manage.
+
+---
+
+## 2 | Eight Normalisation/Transformation Techniques
+
+| #     | Category                      | Flight-column Example                                      | Purpose                                            |
+| ----- | ----------------------------- | ---------------------------------------------------------- | -------------------------------------------------- |
+| **1** | **Categorical harmonisation** | `stops → {0,1,2}`                                          | Removes free-text drift (“zero”, “non-stop”, etc.) |
+| **2** | **Time-bucket encoding**      | `departure_time → {Early Morning, Morning…}` ⟶ ordinal 0-5 | Feeds ML models numeric chrono order               |
+| **3** | **Duration unwrap**           | `"2.17"` h ⟶ `130` minutes                                 | Consistent numeric metric                          |
+| **4** | **Z-score scaling**           | `price_z = (price – µ) / σ`                                | Detect over/under-priced outliers                  |
+| **5** | **Min-max scaling**           | `days_left` 0-365 ⟶ 0-1                                    | Feature range for UI sliders                       |
+| **6** | **Frequency encoding**        | `airline_freq` = share of flights                          | Captures carrier popularity                        |
+| **7** | **One-hot vectors**           | `class ∈ {Economy, Business}`                              | Keeps class bias explicit                          |
+| **8** | **Log-transform**             | `log_price = ln(price)`                                    | Normalises right-skewed fare tail                  |
+
+Each transformation lives in `etl/transform.py` with unit‐tests (`pytest`) and Great Expectations checks.
+
+---
+
+## 3 | Eight Visual Styles Showcased in the Dashboard
+
+| #     | Component                                                                   | Insight Conveyed                 |
+| ----- | --------------------------------------------------------------------------- | -------------------------------- |
+| **1** | **Line chart** (Chart.js) – Median price vs. `days_left`                    | Price-decay curve                |
+| **2** | **Box-and-whisker** – Fare distribution per airline                         | Detect carrier outliers          |
+| **3** | **Heat-map calendar** – Avg. price by departure weekday & month             | Seasonality hotspots             |
+| **4** | **Stacked area** – Class mix share over time                                | Economy vs. Business trends      |
+| **5** | **Violin plot** – Flight **duration** by `stops` count                      | Time cost of layovers            |
+| **6** | **Bullet KPI cards** – Data-quality score, null-rate, row latency           | Health at a glance               |
+| **7** | **Radar chart** – Z-scored metrics (price, duration, days\_left) by airline | Multi-metric carrier ranking     |
+| **8** | **Live ticker table** (HTMX stream) – Last 20 price updates                 | “Bloomberg”-style real-time feed |
+
+All charts share the Tailwind theme but differ in form, emphasising your versatility with data storytelling.
+
+---
+
+## 4 | 7-Day Sprint Plan (updated)
+
+| Day   | Deliverables                                                                                | Key Analyst/Engineer Focus |
+| ----- | ------------------------------------------------------------------------------------------- | -------------------------- |
+| **1** | Jupyter EDA of raw Excel → identify anomalies                                               | Problem framing            |
+| **2** | Build **`extract_excel.py`** → convert to partitioned Parquet (`/data/YYYY-MM/…`)           | Efficient columnar storage |
+| **3** | Implement **8 transformations** + tests; generate Great Expectations docs                   | Reproducible cleansing     |
+| **4** | Spin up DuckDB; wire Dapper queries (`flights_latest`, `price_hist`)                        | Embedded SQL access        |
+| **5** | Create Minimal API endpoints + SignalR hub; fake live feed via `python stream_simulator.py` | Real-time backend          |
+| **6** | Tailwind dashboard with **8 visual widgets**; HTMX filters                                  | Interactive UX             |
+| **7** | Docker Compose (Python + API + Nginx); GitHub CI; 90-sec demo video                         | Dev-ops polish             |
+
+---
+
+## 5 | Repository Skeleton
+
+```
+flight-fare-dashboard/
+├─ data/
+│  └─ (Parquet partitions)
+├─ etl/
+│  ├─ extract_excel.py
+│  ├─ transform.py
+│  ├─ stream_simulator.py
+│  └─ tests/
+├─ api/
+│  ├─ Program.cs          # .NET 8 + SignalR
+│  ├─ Repositories/       # Dapper <-> DuckDB ODBC
+│  └─ Models/
+├─ ui/
+│  ├─ index.html
+│  ├─ tailwind.css
+│  └─ js/
+├─ docker-compose.yml
+└─ README.md
+```
+
+---
+
+## 6 | Interview Sound-Bites
+
+* **“No server, still SQL.”** - DuckDB queries Parquet in-process; Dapper maps straight into C# DTOs—easy to demo locally or in CI.
+* **“Eight-layer normalisation.”** - I showcase categorical, numerical, and statistical techniques, each backed by tests and Great Expectations validation.
+* **“Visual buffet.”** - From box-plots to live tickers, the UI proves I can pick the right chart for the story—not just default line graphs.
+* **“One-command spin-up.”** - `docker compose up` builds ETL, API, and Tailwind-served UI in \~90 s.
+
+---
+
+### **Elevator Pitch (final form)**
+
+> “I take a messy Excel flight-fare dump, enforce eight rigorous normalisation steps, store it as efficient Parquet, query it with embedded DuckDB + Dapper (no external DB), and present eight distinct visual perspectives—all containerised, tested, and ready for a hiring manager to explore in one click.”
+
+Use this plan as your project README outline, then iterate feature-by-feature; the result is a **compact yet sophisticated** showcase of both analysis depth and engineering practicality.


### PR DESCRIPTION
## Summary
- clean up README and keep original blueprint as backup
- add Quick start section with all commands needed to set up the dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688be4f3fb84833382a2b714d2c68f86