### PR TITLE
Improve logging across scripts

### DIFF
--- a/etl/extract_excel.py
+++ b/etl/extract_excel.py
@@ -54,9 +54,11 @@ def main() -> None:
                         help="Output folder for bronze Parquet")
     args = parser.parse_args()
 
+    log.info("Starting extraction from %s to %s", args.source, args.out_dir)
     try:
         df = read_source(args.source)
         write_parquet(df, args.out_dir)
+        log.info("Extraction completed successfully.")
     except Exception as exc:
         log.exception("Extraction failed: %s", exc)
         raise SystemExit(1)

--- a/etl/stream_simulator.py
+++ b/etl/stream_simulator.py
@@ -35,6 +35,7 @@ def pick_latest_gold(pattern: str) -> Path:
 def stream(df: pd.DataFrame, rate: float) -> None:
     """Emit one row every `1/rate` seconds (approx)."""
     delay = 1 / rate
+    log.info("Starting stream loop with delay %.2fs", delay)
     try:
         while True:
             row = df.sample(1).to_dict(orient="records")[0]
@@ -43,6 +44,8 @@ def stream(df: pd.DataFrame, rate: float) -> None:
             time.sleep(delay)
     except KeyboardInterrupt:
         log.info("Stopped by user.")
+    finally:
+        log.info("Stream loop ended")
 
 
 # ---------------------------------------------------------------------------#
@@ -54,6 +57,11 @@ def main() -> None:
                    help="Rows per second to emit")
     args = p.parse_args()
 
+    log.info(
+        "Simulator starting with pattern %s at %.2f rows/sec",
+        args.gold,
+        args.rate,
+    )
     try:
         gold_path = pick_latest_gold(args.gold)
         df = pd.read_parquet(gold_path)

--- a/etl/transform.py
+++ b/etl/transform.py
@@ -88,11 +88,15 @@ def main() -> None:
                    help="Output folder for gold Parquet")
     args = p.parse_args()
 
+    log.info(
+        "Starting transform from %s to %s", args.in_dir, args.out_dir
+    )
     try:
         df = load_bronze(args.in_dir)
         df = normalise(df)
         quality_gate(df)
         write_gold(df, args.out_dir)
+        log.info("Transform completed successfully.")
     except Exception as exc:
         log.exception("Transform failed: %s", exc)
         raise SystemExit(1)

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 LOGFILE="run_all.log"
 : > "$LOGFILE"
@@ -10,25 +10,28 @@ log() {
 
 trap 'log "ERROR: script failed at line $LINENO"; exit 1' ERR
 
-log "Installing Python dependencies..."
-pip install -r requirements.txt >> "$LOGFILE" 2>&1
-log "Python dependencies installed successfully."
+run_cmd() {
+  log "Executing: $*"
+  "$@" >> "$LOGFILE" 2>&1
+  local status=$?
+  if [ $status -ne 0 ]; then
+    log "Command failed (exit $status): $*"
+    exit $status
+  fi
+  log "Command succeeded: $*"
+}
 
-log "Extracting and transforming data..."
-python etl/extract_excel.py --source data/raw/airlines_flights_data.csv >> "$LOGFILE" 2>&1
-python etl/transform.py >> "$LOGFILE" 2>&1
-log "Data transformation complete."
+run_cmd pip install -r requirements.txt
 
-log "Building Tailwind CSS..."
+run_cmd python etl/extract_excel.py --source data/raw/airlines_flights_data.csv
+run_cmd python etl/transform.py
+
 pushd ui >> "$LOGFILE"
-npm install >> "$LOGFILE" 2>&1
-npx tailwindcss -o public/tailwind.css --minify >> "$LOGFILE" 2>&1
+run_cmd npm install
+run_cmd npx tailwindcss -o public/tailwind.css --minify
 popd >> "$LOGFILE"
-log "Tailwind build complete."
 
-log "Starting containers with Docker Compose..."
-docker compose up --build -d >> "$LOGFILE" 2>&1
-log "Docker containers started."
+run_cmd docker compose up --build -d
 
 log "Checking dashboard availability..."
 for i in {1..10}; do


### PR DESCRIPTION
## Summary
- enhance extraction script logging
- add start/end logs to transformation step
- detail simulator startup and loop status
- convert run_all.sh to use a `run_cmd` helper for better success/failure logs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d269f46448333a35df081901370af