### PR TITLE
fix: handle missing background processes

### DIFF
--- a/run_all.sh
+++ b/run_all.sh
@@ -75,7 +75,11 @@ $PYTHON_CMD -m http.server 8080 >> ../run_all.log 2>&1 &
 UI_PID=$!
 popd > /dev/null || exit
 
-trap 'log "Stopping..."; kill $API_PID $UI_PID' EXIT
+cleanup() {
+  log "Stopping..."
+  kill "$API_PID" "$UI_PID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
 log "Processes started. API on http://localhost:8000, dashboard on http://localhost:8080"
 
 log "Checking dashboard availability..."


### PR DESCRIPTION
## Summary
- make run_all.sh ignore missing API/UI processes during cleanup

## Testing
- `timeout 15 ./run_all.sh >/tmp/run.log 2>&1`
- `tail -n 20 /tmp/run.log`


------
https://chatgpt.com/codex/tasks/task_e_688dc2d8ef408333a1dc227b09acd4ed