### PR TITLE
Gracefully handle missing data

### DIFF
--- a/api/Program.cs
+++ b/api/Program.cs
@@ -89,7 +89,7 @@ app.MapGet("/health", () => Results.Ok(new { status = "ok", ts = DateTime.UtcNow
    .WithTags("Utility");
 
 // Price history – simple sample query
-app.MapGet("/prices/history", async (IDbConnection conn) =>
+app.MapGet("/prices/history", async (IDbConnection conn, ILogger<Program> logger) =>
 {
     const string sql = """
         SELECT days_left, ROUND(AVG(price),0) AS avg_price
@@ -97,8 +97,16 @@ app.MapGet("/prices/history", async (IDbConnection conn) =>
         GROUP BY days_left
         ORDER BY days_left;
         """;
-    var rows = await conn.QueryAsync(sql);
-    return Results.Ok(rows);
+    try
+    {
+        var rows = await conn.QueryAsync(sql);
+        return Results.Ok(rows);
+    }
+    catch (Exception ex)
+    {
+        logger.LogWarning(ex, "Price history unavailable - returning empty set");
+        return Results.Ok(Array.Empty<object>());
+    }
 })
 .WithName("PriceHistory")
 .WithTags("Prices");

--- a/api/Repositories/FlightRepository.cs
+++ b/api/Repositories/FlightRepository.cs
@@ -1,19 +1,33 @@
 using System.Data;
+using System.Collections.Generic;
+using System.Linq;
 using Dapper;
+using Microsoft.Extensions.Logging;
 
 namespace FlightFareApi.Repositories;
 
 public class FlightRepository
 {
     private readonly IDbConnection _db;
-    public FlightRepository(IDbConnection db)
+    private readonly ILogger<FlightRepository> _logger;
+
+    public FlightRepository(IDbConnection db, ILogger<FlightRepository> logger)
     {
         _db = db;
+        _logger = logger;
     }
 
     public async Task<IEnumerable<dynamic>> GetLatestFlightsAsync()
     {
         const string sql = "SELECT * FROM flights_gold ORDER BY load_ts DESC LIMIT 100";
-        return await _db.QueryAsync(sql);
+        try
+        {
+            return await _db.QueryAsync(sql);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Latest flights unavailable - returning empty set");
+            return Enumerable.Empty<dynamic>();
+        }
     }
 }

--- a/ui/index.html
+++ b/ui/index.html
@@ -21,6 +21,8 @@
     <button id="theme-toggle" class="ml-auto px-3 py-1 rounded bg-white/20 text-sm hover:bg-white/30">🌓</button>
   </header>
 
+  <p id="data-warning" class="p-4 text-center text-red-600"></p>
+
   <!-- KPI cards -->
   <section class="grid grid-cols-2 md:grid-cols-4 gap-4 p-4" id="kpi-cards">
     <!-- These cards can be hydrated via HTMX polling / websocket -->
@@ -125,6 +127,27 @@
        Quick demo data — replace with real fetch/websocket hookups later
     ------------------------------------------------------------------ */
     const ctx = id => document.getElementById(id);
+
+    const warn = msg => {
+      console.warn(msg);
+      document.getElementById('data-warning').textContent = msg;
+    };
+
+    (async () => {
+      try {
+        const res = await fetch('http://localhost:8000/prices/history');
+        if (!res.ok) throw new Error(res.statusText);
+        const data = await res.json();
+        if (!Array.isArray(data) || data.length === 0) {
+          warn('No data available from API');
+        } else {
+          console.log('Loaded sample data', data.slice(0, 3));
+        }
+      } catch (err) {
+        warn('Failed to load data from API');
+        console.error(err);
+      }
+    })();
 
     // 1 ▸ Line chart
     new Chart(ctx('chart-line'), {


### PR DESCRIPTION
## Summary
- return empty sets from API endpoints when source tables are missing and log warnings
- show missing data warnings in dashboard view and console

## Testing
- `dotnet build` *(fails: unable to find required NuGet packages)*
- `npm --prefix ui test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688dc4e72e8883338789a72bbbd61b35