### PR TITLE
feat: allow running API and UI independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,15 @@ The script now launches the API and static web server directly on your
 machine – no Docker required.
 
 ```bash
+# Start API and dashboard together
 ./run_all.sh
+
+# Or run components independently
+./run_all.sh --api-only   # only the API
+./run_all.sh --ui-only    # only the front-end
 ```
+
+Use `--no-api` or `--no-ui` to skip starting a component while running the other.
 
 Run the following commands from the repo root to generate data and launch the dashboard manually.
 

--- a/run_all.sh
+++ b/run_all.sh
@@ -38,77 +38,125 @@ run_cmd_allow_fail() {
     log "Command succeeded: $*"
   fi
 }
+RUN_API=true
+RUN_UI=true
 
-run_cmd pip install -r requirements.txt
+print_usage() {
+  cat <<'EOF'
+Usage: ./run_all.sh [OPTIONS]
+  --api-only   Start only the API
+  --ui-only    Start only the UI
+  --no-api     Skip starting the API
+  --no-ui      Skip starting the UI
+  -h, --help   Show this help and exit
+EOF
+}
 
-run_cmd_allow_fail python etl/extract_excel.py --source data/raw/airlines_flights_data.csv
-run_cmd_allow_fail python etl/transform.py
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --api-only) RUN_API=true; RUN_UI=false ;;
+    --ui-only) RUN_API=false; RUN_UI=true ;;
+    --no-api) RUN_API=false ;;
+    --no-ui) RUN_UI=false ;;
+    -h|--help) print_usage; exit 0 ;;
+    *) echo "Unknown option: $1"; print_usage; exit 1 ;;
+  esac
+  shift
+done
 
-# Warn if no data was produced
-if ! ls data/gold/*.parquet >/dev/null 2>&1; then
-  log "${COL_ERR}No data available; dashboard will load without data${COL_RESET}"
-fi
-
-log "Building UI assets..."
-pushd ui > /dev/null || exit
-run_cmd npm install
-run_cmd npx tailwindcss -o public/tailwind.css --minify
-popd > /dev/null || exit
-
-log "Starting API..."
-pushd api > /dev/null || exit
-dotnet run --urls http://localhost:8000 >> ../run_all.log 2>&1 &
-API_PID=$!
-popd > /dev/null || exit
-
-log "Starting local web server..."
-pushd ui > /dev/null || exit
-
-# Use python3 if available, otherwise fall back to python
-if command -v python3 >/dev/null; then
-  PYTHON_CMD=python3
+if [ "$RUN_API" = true ]; then
+  run_cmd pip install -r requirements.txt
+  run_cmd_allow_fail python etl/extract_excel.py --source data/raw/airlines_flights_data.csv
+  run_cmd_allow_fail python etl/transform.py
+  if ! ls data/gold/*.parquet >/dev/null 2>&1; then
+    log "${COL_ERR}No data available; dashboard will load without data${COL_RESET}"
+  fi
 else
-  PYTHON_CMD=python
+  log "API setup skipped via flag"
 fi
 
-$PYTHON_CMD -m http.server 8080 >> ../run_all.log 2>&1 &
-UI_PID=$!
-popd > /dev/null || exit
+if [ "$RUN_UI" = true ]; then
+  log "Building UI assets..."
+  pushd ui > /dev/null || exit
+  run_cmd npm install
+  run_cmd npx tailwindcss -o public/tailwind.css --minify
+  popd > /dev/null || exit
+else
+  log "UI asset build skipped via flag"
+fi
+
+if [ "$RUN_API" = true ]; then
+  log "Starting API..."
+  pushd api > /dev/null || exit
+  dotnet run --urls http://localhost:8000 >> ../run_all.log 2>&1 &
+  API_PID=$!
+  popd > /dev/null || exit
+else
+  log "API not started"
+fi
+
+if [ "$RUN_UI" = true ]; then
+  log "Starting local web server..."
+  pushd ui > /dev/null || exit
+
+  # Use python3 if available, otherwise fall back to python
+  if command -v python3 >/dev/null; then
+    PYTHON_CMD=python3
+  else
+    PYTHON_CMD=python
+  fi
+
+  $PYTHON_CMD -m http.server 8080 >> ../run_all.log 2>&1 &
+  UI_PID=$!
+  popd > /dev/null || exit
+else
+  log "UI not started"
+fi
 
 cleanup() {
   log "Stopping..."
-  kill "$API_PID" "$UI_PID" >/dev/null 2>&1 || true
+  [ -n "${API_PID:-}" ] && kill "$API_PID" >/dev/null 2>&1 || true
+  [ -n "${UI_PID:-}" ] && kill "$UI_PID" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
-log "Processes started. API on http://localhost:8000, dashboard on http://localhost:8080"
 
-log "Checking dashboard availability..."
-for _ in {1..10}; do
-  if curl -sSf http://localhost:8080 > /dev/null; then
-    log "Dashboard is available."
-    break
-  else
-    log "Waiting for dashboard..."
-    sleep 2
-  fi
-done
-
-log "Attempting to open dashboard in default browser..."
-if command -v xdg-open >/dev/null; then
-  xdg-open http://localhost:8080 >> "$LOGFILE" 2>&1 &
-elif command -v open >/dev/null; then
-  open http://localhost:8080 >> "$LOGFILE" 2>&1 &
-elif command -v cmd.exe >/dev/null; then
-  cmd.exe /c start "" http://localhost:8080 >> "$LOGFILE" 2>&1 &
-elif command -v powershell.exe >/dev/null; then
-  powershell.exe -NoProfile Start-Process http://localhost:8080 >> "$LOGFILE" 2>&1 &
-elif command -v python3 >/dev/null; then
-  python3 -m webbrowser http://localhost:8080 >> "$LOGFILE" 2>&1 &
-elif command -v python >/dev/null; then
-  python -m webbrowser http://localhost:8080 >> "$LOGFILE" 2>&1 &
-else
-  log "Could not detect a method to open a browser automatically."
+if [ "$RUN_API" = true ]; then
+  log "API available on http://localhost:8000"
+fi
+if [ "$RUN_UI" = true ]; then
+  log "Dashboard available on http://localhost:8080"
 fi
 
-log "All done. Access the dashboard at http://localhost:8080"
-wait $API_PID $UI_PID || true
+if [ "$RUN_UI" = true ]; then
+  log "Checking dashboard availability..."
+  for _ in {1..10}; do
+    if curl -sSf http://localhost:8080 > /dev/null; then
+      log "Dashboard is available."
+      break
+    else
+      log "Waiting for dashboard..."
+      sleep 2
+    fi
+  done
+
+  log "Attempting to open dashboard in default browser..."
+  if command -v xdg-open >/dev/null; then
+    xdg-open http://localhost:8080 >> "$LOGFILE" 2>&1 &
+  elif command -v open >/dev/null; then
+    open http://localhost:8080 >> "$LOGFILE" 2>&1 &
+  elif command -v cmd.exe >/dev/null; then
+    cmd.exe /c start "" http://localhost:8080 >> "$LOGFILE" 2>&1 &
+  elif command -v powershell.exe >/dev/null; then
+    powershell.exe -NoProfile Start-Process http://localhost:8080 >> "$LOGFILE" 2>&1 &
+  elif command -v python3 >/dev/null; then
+    python3 -m webbrowser http://localhost:8080 >> "$LOGFILE" 2>&1 &
+  elif command -v python >/dev/null; then
+    python -m webbrowser http://localhost:8080 >> "$LOGFILE" 2>&1 &
+  else
+    log "Could not detect a method to open a browser automatically."
+  fi
+
+  log "All done. Access the dashboard at http://localhost:8080"
+fi
+
+wait ${API_PID:-} ${UI_PID:-} || true


### PR DESCRIPTION
## Summary
- add flags to run only the API or UI so each can run independently
- document new flags and how to skip components in `run_all.sh`

## Testing
- `bash -n run_all.sh`
- `./run_all.sh --help`
- `./run_all.sh --no-api --no-ui`


------
https://chatgpt.com/codex/tasks/task_e_688dcc76338c8333ae513dfe57aa7838